### PR TITLE
Allow autolabel to match download path.

### DIFF
--- a/labelplus/common/config/autolabel.py
+++ b/labelplus/common/config/autolabel.py
@@ -38,12 +38,14 @@ import re
 
 
 PROP_NAME = "Name"
+PROP_PATH = "Path"
 PROP_TRACKER = "Tracker"
 PROP_FILES = "Any file"
 PROP_LABEL = "Label"
 
 PROPS = (
   PROP_NAME,
+  PROP_PATH,
   PROP_TRACKER,
   PROP_FILES,
   PROP_LABEL

--- a/labelplus/core/core.py
+++ b/labelplus/core/core.py
@@ -1579,14 +1579,16 @@ class Core(CorePluginBase):
     match_all = options["autolabel_match_all"]
 
     status = deluge.component.get("Core").get_torrent_status(torrent_id,
-      ["name", "trackers", "files", "label"])
+      ["name", "save_path", "trackers", "files", "label"])
 
     name = status["name"]
+    path = status["save_path"]
     trackers = [x["url"] for x in status["trackers"]]
     files = [x["path"] for x in status["files"]]
 
     props = {
       labelplus.common.config.autolabel.PROP_NAME: [name],
+      labelplus.common.config.autolabel.PROP_PATH: [path],
       labelplus.common.config.autolabel.PROP_TRACKER: trackers,
       labelplus.common.config.autolabel.PROP_FILES: files,
       labelplus.common.config.autolabel.PROP_LABEL: [],


### PR DESCRIPTION
Due to YaRSS2 not having support for lablelplus labels, I found it fairly easy to use the download path to automatically add labels by just using the download path.